### PR TITLE
Bugfix/missing ctx flags

### DIFF
--- a/src-tauri/src/ffmpeg/parser.rs
+++ b/src-tauri/src/ffmpeg/parser.rs
@@ -514,7 +514,7 @@ fn parse_contexts(ffmpeg: &str, env_map: &HashMap<String, String>) -> Result<Vec
                         if let Some(type_end) = rest.find('>') {
                             let type_str = &rest[type_start + 1..type_end];
                             opt.r#type = Some(format!("<{}>", type_str));
-                            opt.no_args = matches!(type_str, "boolean" | "flags");
+                            opt.no_args = matches!(type_str, "boolean");
 
                             // Extract category (scope markers like E..V.., ED.VA..)
                             let after_type = rest[type_end + 1..].trim_start();
@@ -544,7 +544,12 @@ fn parse_contexts(ffmpeg: &str, env_map: &HashMap<String, String>) -> Result<Vec
             // Enum value line (indented further, no dash prefix)
             else if line.starts_with("     ") && !line.trim_start().starts_with('-') {
                 if let Some(ref mut opt) = current_opt {
-                    if let Some(enum_val) = line.split_whitespace().next() {
+                    if opt.r#type.as_deref() == Some("<flags>") {
+                        match &mut opt.desc {
+                            Some(desc) => desc.push_str(&format!("<br>{line}")),
+                            None => opt.desc = Some(line.to_string()),
+                        };
+                    } else if let Some(enum_val) = line.split_whitespace().next() {
                         opt.enum_vals.push(enum_val.to_string());
 
                         // Mark as enum type if not already


### PR DESCRIPTION
# 🦀 Pull Request

## 📋 Description

This PR fixes a bug where certain important FFmpeg flags (e.g. `-g`)
were not being parsed correctly. The issue stemmed from the complexity
of parsing FFmpeg's `AVOption` context flags, which are located in
non-trivial sections of the FFmpeg help output.\
This update introduces a dedicated function that accurately parses these
`Ctx AVOptions`, ensuring all relevant flags are captured and handled
properly.

## 🧩 Changes

-   Added a new function to handle parsing of FFmpeg `Ctx AVOptions`
-   Fixed missing flag parsing (e.g. `-g` and similar)
-   Improved robustness of FFmpeg option extraction logic

## 🔗 Related Issue

Closes \# (if applicable)

## ✅ Checklist

-   [x] Builds successfully (`cargo build`)
-   [x] Code formatted (`cargo fmt`)
-   [x] Lint check passed (`cargo clippy`)
-   [x] PR description is clear
