### PR TITLE
Fixed: missing options, empty enums representation

### DIFF
--- a/src-tauri/src/ffmpeg/parser.rs
+++ b/src-tauri/src/ffmpeg/parser.rs
@@ -92,6 +92,7 @@ pub fn parse_ffmpeg(ffmpeg: &str, env_str: &str) -> Result<Vec<Node>> {
         });
         handles.push(h);
     }
+
     // contexts
     {
         let ff = ffmpeg.to_string();
@@ -209,6 +210,10 @@ fn parse_general(
         for opt_line in filtered.iter() {
             if section_re.is_match(opt_line) {
                 if let Some(mut prev) = current_node.take() {
+                    if let Some(opt) = current_opt.take() {
+                        prev.options.push(opt);
+                    }
+
                     // --- Add "enable" option if timeline support is mentioned ---
                     if timeline_re.is_match(&String::from_utf8_lossy(help_text)) {
                         let opt = OptionEntry {
@@ -290,7 +295,7 @@ fn parse_general(
             }
         }
         if let Some(mut n) = current_node.take() {
-            if let Some(opt) = current_opt {
+            if let Some(opt) = current_opt.take() {
                 n.options.push(opt);
             }
             // --- Add "enable" option if timeline support is mentioned ---

--- a/src/modules/graph/nodes.js
+++ b/src/modules/graph/nodes.js
@@ -10,9 +10,12 @@ import * as graph_consts from './constants.js';
 
 const ffmpegTypeMap = {
     "<enum>": (node, opt) => {
-        let values = [""].concat(opt.enum_vals || []);
-        node.addProperty(opt.flag, "", "enum", { values });
-        node.addWidget("combo", opt.flag, "", { property: opt.flag, values });
+        if(opt.enum_vals) {
+            let values = [""].concat(opt.enum_vals);
+            node.addProperty(opt.flag, "", "enum", { values });
+            node.addWidget("combo", opt.flag, "", { property: opt.flag, values });
+        }
+        else ffmpegTypeMap["<string>"](node, opt);
     },
 
     "<bool>": (node, opt) => {
@@ -56,15 +59,21 @@ const ffmpegTypeMap = {
     },
 
     "<pix_fmt>": (node, opt) => {
-        let values = [""].concat(opt.values || []);
-        node.addProperty(opt.flag, "", "enum", { values });
-        node.addWidget("combo", opt.flag, "", { property: opt.flag, values });
+        if(opt.values) {
+            let values = [""].concat(opt.values);
+            node.addProperty(opt.flag, "", "enum", { values });
+            node.addWidget("combo", opt.flag, "", { property: opt.flag, values });
+        }
+        else ffmpegTypeMap["<string>"](node, opt);
     },
 
     "<sample_fmt>": (node, opt) => {
-        let values = [""].concat(opt.values || []);
-        node.addProperty(opt.flag, "", "enum", { values });
-        node.addWidget("combo", opt.flag, "", { property: opt.flag, values });
+        if(opt.values) {
+            let values = [""].concat(opt.values);
+            node.addProperty(opt.flag, "", "enum", { values });
+            node.addWidget("combo", opt.flag, "", { property: opt.flag, values });
+        }
+        else ffmpegTypeMap["<string>"](node, opt);
     },
 
     "<color>": (node, opt) => {
@@ -73,9 +82,12 @@ const ffmpegTypeMap = {
     },
 
     "<channel_layout>": (node, opt) => {
-        let values = [""].concat(opt.values || []);
-        node.addProperty(opt.flag, "", "enum", { values });
-        node.addWidget("combo", opt.flag, "", { property: opt.flag, values });
+        if(opt.values) {
+            let values = [""].concat(opt.values);
+            node.addProperty(opt.flag, "", "enum", { values });
+            node.addWidget("combo", opt.flag, "", { property: opt.flag, values });
+        }
+        else ffmpegTypeMap["<string>"](node, opt);
     }
 };
 


### PR DESCRIPTION
# 🦀 Pull Request

## 📋 Description
This PR fixes two issues in the parser related to enum handling and node option parsing. These fixes improve robustness when working with incomplete or inconsistent metadata provided by ffmpeg.

## 🧩 Changes
- Fixed enum parsing: enums without defined values now fall back to `string` to allow user input, since ffmpeg does not always provide enum values.
- Fixed missing node options caused by not saving parsed data before advancing to the next parsing step.

## 🔗 Related Issue
Closes # (if applicable)

## ✅ Checklist
- [x] Builds successfully (`cargo build`)
- [x] Code formatted (`cargo fmt`)
- [x] Lint check passed (`cargo clippy`)
- [x] PR description is clear