### PR TITLE
Removed: wildcard feature for output

### DIFF
--- a/src/modules/graph/utils.js
+++ b/src/modules/graph/utils.js
@@ -70,7 +70,7 @@ async function expandFfmpegCommand(ffmpegCommand, options = {}) {
         }
         
         // Check if this looks like an output (has wildcard, placeholder, or is a file path)
-        if (arg.includes('*') || placeholderRegex.test(arg)) {
+        if (placeholderRegex.test(arg)) {
             outputPatterns.push(arg);
             outputPatternIndices.push(i);
         } else if (!arg.startsWith('[') && !arg.startsWith('-')) {
@@ -85,9 +85,8 @@ async function expandFfmpegCommand(ffmpegCommand, options = {}) {
     // ═══════════════════════════════════════════════════════════════════════════
     const hasPlaceholders = outputPatterns.some(p => placeholderRegex.test(p));
     const hasInputWildcards = inputWildcards.length > 0;
-    const hasOutputWildcards = outputPatterns.some(p => p.includes('*'));
     
-    if (!hasInputWildcards && !hasOutputWildcards && !hasPlaceholders) {
+    if (!hasInputWildcards && !hasPlaceholders) {
         return [ffmpegCommand];
     }
 
@@ -127,7 +126,7 @@ async function expandFfmpegCommand(ffmpegCommand, options = {}) {
     // ═══════════════════════════════════════════════════════════════════════════
     // STEP 7: Detect injection mode automatically
     // ═══════════════════════════════════════════════════════════════════════════
-    const hasNamePlaceholder = outputPatterns.some(p => p.includes('{name}') || p.includes('*'));
+    const hasNamePlaceholder = outputPatterns.some(p => p.includes('{name}'));
     const hasHashPlaceholder = outputPatterns.some(p => p.includes('{hash}'));
     const hasIndexPlaceholder = outputPatterns.some(p => p.includes('{index}'));
 


### PR DESCRIPTION
# 🦀 Pull Request

## 📋 Description
This PR refines ffmpeg command expansion by removing wildcard (`*`) replacement in output patterns. Previously, `*` in outputs could break complex filter chains when used as a placeholder. Now, only explicit `{name}`, `{hash}`, and `{index}` placeholders are expanded, improving reliability and avoiding unintended filename injection.

## 🧩 Changes
- Removed wildcard (`*`) handling in output patterns to prevent breaking complex ffmpeg filters.
- Only `{name}`, `{hash}`, and `{index}` placeholders are now expanded in outputs.
- Adjusted early-exit logic to skip expansion if there are no input wildcards or placeholders.
- Minor cleanup of injection mode detection logic.

## 🔗 Related Issue
Closes # (if applicable)

## ✅ Checklist
- [x] Builds successfully
- [x] Code formatted
- [x] Lint check passed
- [x] PR description is clear