### PR TITLE
Allow args without description

### DIFF
--- a/src-tauri/src/ffmpeg/parser.rs
+++ b/src-tauri/src/ffmpeg/parser.rs
@@ -249,15 +249,18 @@ fn parse_general(
                     if header_re.is_match(opt_line) {
                         // New flag line: "-flag <type> category ..."
                         let parts: Vec<&str> = opt_line.split_whitespace().collect();
-                        if parts.len() > 3 {
+                        if parts.len() > 2 {
                             is_dup_fields = false;
-                            let desc: String =
-                                parts.iter().skip(3).fold(String::new(), |acc, s| acc + s);
-                            if repeated_opt.contains(&desc) {
-                                is_dup_fields = true;
-                                continue;
-                            } else {
-                                repeated_opt.insert(desc);
+                            // Not all args have description
+                            if parts.len() > 3 {
+                                let desc: String =
+                                    parts.iter().skip(3).fold(String::new(), |acc, s| acc + s);
+                                if repeated_opt.contains(&desc) {
+                                    is_dup_fields = true;
+                                    continue;
+                                } else {
+                                    repeated_opt.insert(desc);
+                                }
                             }
 
                             if let Some(prev) = current_opt.take() {


### PR DESCRIPTION
# 🦀 Pull Request

## 📋 Description
This PR fixes a bug in the parser where arguments without descriptions were being skipped. All arguments, regardless of whether a description is present, are now correctly parsed and included.

## 🧩 Changes
- Ensures arguments without descriptions are not skipped during parsing.
- Improves robustness of argument parsing logic for incomplete metadata.
- Minor code cleanup for consistent handling of optional fields.

## 🔗 Related Issue
Closes # (if applicable)

## ✅ Checklist
- [x] Builds successfully
- [x] Code formatted
- [x] Lint check passed
- [x] PR description is clear