### PR TITLE
Added: quotes to handle paths with names

### DIFF
--- a/src/modules/core/format.js
+++ b/src/modules/core/format.js
@@ -36,3 +36,11 @@ export function textToPastelColor(text) {
   const hash = textToHash(text);
   return hashToPastelColor(hash);
 }
+
+// Ensure a string is quoted (if not already)
+export function ensureQuoted(str) {
+  if (typeof str !== 'string') return str;
+  return (/^(['"]).*\1$/).test(str)
+    ? str
+    : `"${str.replace(/(^['"]|['"]$)/g, '')}"`;
+}

--- a/src/modules/graph/nodes.js
+++ b/src/modules/graph/nodes.js
@@ -5,6 +5,7 @@ const { invoke } = window.__TAURI__.core;
 const { open, save } = window.__TAURI__.dialog;
 
 import { addLogEntry } from '../logs/logs.js';
+import { ensureQuoted } from '../core/format.js';
 import * as graph_consts from './constants.js';
 
 
@@ -345,7 +346,7 @@ function make_io_nodes() {
             (dec_v ? "-c:v " + dec_v + " " : "") +
             (d ? d + " " : "") +
             (g ? g + " " : "") +
-            "-i " + str
+            "-i " + ensureQuoted(str)
         );
 
         this.setOutputData(0, {
@@ -486,7 +487,7 @@ function make_io_nodes() {
             (g ? g + " " : "") +
             (enc_a ? "-c:a " + enc_a + " " : "") +
             (enc_v ? "-c:v " + enc_v + " " : "") +
-            path);
+            ensureQuoted(path));
     };
     ffoutput.prototype.onDrawForeground = function (ctx) {
 


### PR DESCRIPTION
# 🦀 Pull Request

## 📋 Description
This PR adds proper quoting for file paths to ensure paths containing spaces or special characters are handled correctly when building command strings (e.g., ffmpeg arguments). This prevents malformed commands and runtime errors when paths are not already quoted.

## 🧩 Changes
- Added `ensureQuoted` utility to safely wrap string paths in quotes
- Updated graph I/O node command construction to use quoted input/output paths
- Preserved existing quotes to avoid double-quoting

## 🔗 Related Issue
Closes # (if applicable)

## ✅ Checklist
- [x] Builds successfully (`cargo build`)
- [x] Code formatted (`cargo fmt`)
- [x] Lint check passed (`cargo clippy`)
- [x] PR description is clear
