### PR TITLE
Feature/undo redo

### DIFF
--- a/src/modules/graph/core.js
+++ b/src/modules/graph/core.js
@@ -1,6 +1,12 @@
 // graph/core.js
 // Core graph functionality and canvas management
 
+import { GraphUndoManager } from './undo_redo.js';
+
+// Global (per graph/workflow) undo manager instance attached to window for cross-module access
+window.__GRAPH_UNDO_MGR__ = null;
+window.__CURRENT_GRAPH__ = null;
+
 // DOM elements
 const graph_zone = document.getElementById('graph-zone');
 const litegraph_canvas = document.getElementById("litegraph-canvas");
@@ -28,6 +34,60 @@ function initializeCanvas() {
         canvas.setDirty(true, true);
     });
     resizeObserver.observe(graph_zone);
+
+  // Initialize or rebind per-graph undo/redo manager (in-memory, capped history)
+  function ensureGraphUndoManager() {
+    if (window.__CURRENT_GRAPH__ === graph && window.__GRAPH_UNDO_MGR__) {
+      return;
+    }
+    window.__GRAPH_UNDO_MGR__ = new GraphUndoManager(graph, { maxHistory: 10 });
+    window.__CURRENT_GRAPH__ = graph;
+    const existingAfter = graph.onAfterChange;
+    graph.onAfterChange = function(g, info) {
+      if (typeof existingAfter === 'function') existingAfter(g, info);
+      if (window.__GRAPH_UNDO_MGR__ && !window.__GRAPH_UNDO_MGR__.isApplying) {
+        window.__GRAPH_UNDO_MGR__.enqueueSnapshot();
+      }
+    };
+  }
+  try {
+      ensureGraphUndoManager();
+
+      // Keyboard shortcuts: Undo/Redo (Cmd/Ctrl+Z / Cmd/Ctrl+Y)
+      document.addEventListener('keydown', (e) => {
+        const isMac = navigator.platform.toLowerCase().includes('mac');
+        const ctrlOrCmd = isMac ? e.metaKey : e.ctrlKey;
+        if (!ctrlOrCmd) return;
+        const key = e.key.toLowerCase();
+        if (key === 'z') {
+          e.preventDefault();
+          if (e.shiftKey) {
+            window.__GRAPH_UNDO_MGR__ && window.__GRAPH_UNDO_MGR__.redo();
+          } else {
+            window.__GRAPH_UNDO_MGR__ && window.__GRAPH_UNDO_MGR__.undo();
+          }
+        } else if (key === 'y') {
+          e.preventDefault();
+          window.__GRAPH_UNDO_MGR__ && window.__GRAPH_UNDO_MGR__.redo();
+        }
+      });
+
+      // Workflow change watcher: ensure undo manager rebinds if graph object changes
+      // (actual reset happens in workflows.js when workflow loads)
+      try {
+          let _lastGraph = window.__CURRENT_GRAPH__ || null;
+          setInterval(() => {
+              if (graph && graph !== _lastGraph) {
+                  _lastGraph = graph;
+                  ensureGraphUndoManager();
+              }
+          }, 1000);
+      } catch (e) {
+          console.warn('GraphUndoManager workflow watcher failed:', e);
+      }
+  } catch (e) {
+      console.warn('GraphUndoManager initialization failed:', e);
+  }
 }
 
 // Canvas visibility management

--- a/src/modules/graph/import_export.js
+++ b/src/modules/graph/import_export.js
@@ -133,9 +133,12 @@ function initializeImportExport() {
 
         try {
             readTextFile(event.payload.paths[0]).then(function(content) {
-                const serialized = graph.serialize();
                 graph.configure(mergeGraphs(graph.serialize(), JSON.parse(content)));
                 addLogEntry("success", "Graph successfully imported!");
+                // Reset undo/redo history for the newly loaded graph
+                if (window.__GRAPH_UNDO_MGR__) {
+                    window.__GRAPH_UNDO_MGR__.resetHistory();
+                }
             });
         } catch (error) {
             addLogEntry("error", "Caught error:" + error);

--- a/src/modules/graph/undo_redo.js
+++ b/src/modules/graph/undo_redo.js
@@ -1,0 +1,120 @@
+// GraphUndoManager: per-graph in-memory undo/redo (max 10 snapshots)
+
+export class GraphUndoManager {
+  constructor(graph, options = {}) {
+    this.graph = graph;
+    this.maxHistory = options.maxHistory ?? 10;
+    this.history = [];
+    this.currentIndex = -1;
+    this.isApplying = false;
+    // Debounce: batch multiple rapid changes into a single snapshot
+    this._debounceDelay = 250; // ms
+    this._debounceTimer = null;
+    this._pendingState = null;
+    this._seedInitialState();
+  }
+
+  _seedInitialState() {
+    const state = this._cloneState(this.graph.serialize());
+    this.history = [state];
+    this.currentIndex = 0;
+  }
+
+  _cloneState(state) {
+    return JSON.stringify(state);
+  }
+
+  canUndo() {
+    return this.currentIndex > 0;
+  }
+
+  canRedo() {
+    return this.currentIndex < this.history.length - 1;
+  }
+
+  // Capture a new snapshot after a change (debounced to batch multiple changes)
+  enqueueSnapshot() {
+    if (this.isApplying) return;
+    // Debounce: store the latest state and commit after a short delay
+    this._pendingState = this._cloneState(this.graph.serialize());
+    if (this._debounceTimer) {
+      clearTimeout(this._debounceTimer);
+    }
+    this._debounceTimer = setTimeout(() => this._commitPendingSnapshot(), this._debounceDelay);
+  }
+
+  _commitPendingSnapshot() {
+    const nextState = this._pendingState;
+    this._pendingState = null;
+    this._debounceTimer = null;
+    if (!nextState) return;
+    const last = (this.currentIndex >= 0 && this.currentIndex < this.history.length) ? this.history[this.currentIndex] : null;
+    if (last && JSON.stringify(nextState) === JSON.stringify(last)) {
+      return;
+    }
+    // If we had undone some steps, truncate the redo path
+    if (this.currentIndex < this.history.length - 1) {
+      this.history = this.history.slice(0, this.currentIndex + 1);
+    }
+    this.history.push(nextState);
+    if (this.history.length > this.maxHistory) {
+      this.history.shift();
+      this.currentIndex = this.maxHistory - 1;
+    } else {
+      this.currentIndex = this.history.length - 1;
+    }
+  }
+
+  _applySnapshot(state) {
+    this.isApplying = true;
+    try {
+      if (typeof state !== 'string' || state === null) {
+        console.warn("GraphUndoManager: invalid snapshot state, skipping restore");
+        return;
+      }
+      this.graph.configure(JSON.parse(state));
+      if (typeof this.graph.updateExecutionOrder === 'function') {
+        this.graph.updateExecutionOrder();
+      }
+    } catch (e) {
+      console.error("GraphUndoManager: failed to apply snapshot", e);
+    } finally {
+      this.isApplying = false;
+    }
+  }
+
+  undo() {
+    if (!this.canUndo()) return;
+    const targetIndex = this.currentIndex - 1;
+    if (targetIndex < 0 || targetIndex >= this.history.length) return;
+    const snapshot = this.history[targetIndex];
+    this._applySnapshot(snapshot);
+    this.currentIndex = targetIndex;
+  }
+
+  redo() {
+    if (!this.canRedo()) return;
+    const targetIndex = this.currentIndex + 1;
+    if (targetIndex < 0 || targetIndex >= this.history.length) return;
+    const snapshot = this.history[targetIndex];
+    this._applySnapshot(snapshot);
+    this.currentIndex = targetIndex;
+  }
+
+  resetHistory() {
+    // Cancel any pending snapshot
+    if (this._debounceTimer) {
+      clearTimeout(this._debounceTimer);
+      this._debounceTimer = null;
+      this._pendingState = null;
+    }
+    const current = this._cloneState(this.graph.serialize());
+    this.history = [current];
+    this.currentIndex = 0;
+  }
+
+  // Optional helper for tests/debugging
+  getCurrentState() {
+    return this._cloneState(this.history[this.currentIndex]);
+  }
+}

--- a/src/modules/workflows/workflows.js
+++ b/src/modules/workflows/workflows.js
@@ -2,7 +2,7 @@ import { addLogEntry } from '../logs/logs.js';
 import { showLoading, hideLoading, updateLoadingProgress, updateLoadingDetails } from '../ui/loading.js';
 import { showAddModal, showEditModal, hideModal, resetForm } from '../ui/modal.js';
 import { exportGraph } from '../graph/import_export.js';
-import { make_nodes, make_io_nodes } from '../graph/nodes.js';
+import { make_nodes, make_io_nodes, make_control_node } from '../graph/nodes.js';
 import { graph, canvas, updateCanvasVisibility } from '../graph/core.js';
 
 const { listen, once } = window.__TAURI__.event;
@@ -98,6 +98,7 @@ listen('get_workflow_listener', (event) => {
 
     make_nodes(data["nodes"]);
     make_io_nodes();
+    make_control_node();
     if(data["graph"]) graph.configure(JSON.parse(data["graph"]));
 });
 
@@ -205,6 +206,7 @@ export async function reconfig_graph(path) {
         
         make_nodes(data);
         make_io_nodes();
+        make_control_node();
         addLogEntry('info', `Succesfuly reconfigured litegraph for: ` + path);
         hideLoading();
     });

--- a/src/modules/workflows/workflows.js
+++ b/src/modules/workflows/workflows.js
@@ -4,6 +4,7 @@ import { showAddModal, showEditModal, hideModal, resetForm } from '../ui/modal.j
 import { exportGraph } from '../graph/import_export.js';
 import { make_nodes, make_io_nodes, make_control_node } from '../graph/nodes.js';
 import { graph, canvas, updateCanvasVisibility } from '../graph/core.js';
+import { GraphUndoManager } from '../graph/undo_redo.js';
 
 const { listen, once } = window.__TAURI__.event;
 const { invoke } = window.__TAURI__.core;
@@ -100,6 +101,11 @@ listen('get_workflow_listener', (event) => {
     make_io_nodes();
     make_control_node();
     if(data["graph"]) graph.configure(JSON.parse(data["graph"]));
+
+    // Reset undo history when loading new workflow
+    if (window.__GRAPH_UNDO_MGR__) {
+        window.__GRAPH_UNDO_MGR__.resetHistory();
+    }
 });
 
 export async function selectWorkflow(name) {


### PR DESCRIPTION
# 🦀 Pull Request

## 📋 Description
This PR introduces undo/redo functionality to the graph editor and adds a new **Variables(experemental)** node.

The Variables node allows users to define and manage all graph configuration values in a single place using a CSV-formatted input. This centralizes configuration management and improves usability and maintainability.

## 🧩 Changes
List the main changes made in this PR:
- Added undo functionality
- Added redo functionality
- Implemented state history management
- Added new **Variables** node
- Enabled CSV-based configuration input for centralized graph settings

## 🔗 Related Issue
Closes # (if applicable)

## ✅ Checklist
- [x] Builds successfully (`cargo build`)
- [x] Code formatted (`cargo fmt`)
- [x] Lint check passed (`cargo clippy`)
- [x] PR description is clear